### PR TITLE
[BUGFIX] Correctly pass library-url path to H5P

### DIFF
--- a/Classes/H5PAdapter/TYPO3H5P.php
+++ b/Classes/H5PAdapter/TYPO3H5P.php
@@ -106,7 +106,7 @@ class TYPO3H5P
             self::$core = new \H5PCore(
                 self::$interface,
                 new FileAdapter(),
-                $settings['h5pPublicFolder']['url'],
+                rtrim($settings['h5pPublicFolder']['url'], '/'),
                 $this->getLanguage(),
                 (bool) $settings['enableExport']
             );

--- a/Classes/Service/H5PIntegrationService.php
+++ b/Classes/Service/H5PIntegrationService.php
@@ -298,7 +298,7 @@ class H5PIntegrationService implements SingletonInterface
             );
             $files = $this->getH5PCoreInstance()->getDependenciesFiles(
                 $preloadedDependencies,
-                $this->h5pSettings['h5pPublicFolder']['url']
+                rtrim($this->h5pSettings['h5pPublicFolder']['url'], '/')
             );
 
             $this->addCustomStylesheet($files['styles']);


### PR DESCRIPTION
The URL is used to construct paths to H5P editor
libraries, which are already have a leading slash.

Resolves: #5